### PR TITLE
fix: 🐛 not clear timer will cause memory leak

### DIFF
--- a/src/components/activity-item/index.tsx
+++ b/src/components/activity-item/index.tsx
@@ -9,10 +9,16 @@ type ActivityItemProps = {
 }
 const ActivityItem: React.FC<ActivityItemProps> = (props) => {
   const [opacity, setOpacity] = React.useState(0)
+  const timer = React.useRef<number | null>(null)
   React.useEffect(() => {
-    setTimeout(() => {
+    timer.current = setTimeout(() => {
       setOpacity(1)
     }, 500)
+    return () => {
+      if (timer.current) {
+        clearTimeout(timer.current)
+      }
+    }
   }, [])
   const { title, pubTime, summary, img, id } = props.activityInfo || {}
   return (


### PR DESCRIPTION
settimeout not clear will cause current fibernode still stay in memory,
with a hook call, this fiber node will cause memory leak

BREAKING CHANGE: 🧨 none

✅ Closes: #19